### PR TITLE
removed 'lunar' from 'testing-ansible-7'

### DIFF
--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -37,13 +37,11 @@ testing-ansible-7:
       dists:
         - jammy
         - kinetic
-        - lunar
     - name: ansible
       version_specifier: "~=7.0a"
       dists:
         - jammy
         - kinetic
-        - lunar
 testing-ansible-ansible-5:
   github_branch: ansible-5
   launchpad_ppa: testing-ansible
@@ -69,13 +67,11 @@ testing-ansible-ansible-7:
       dists:
         - jammy
         - kinetic
-        - lunar
     - name: ansible
       version_specifier: "~=7.0a"
       dists:
         - jammy
         - kinetic
-        - lunar
 ansible-5:
   packages:
     - name: resolvelib


### PR DESCRIPTION
ansible-core : Depends: python3-resolvelib (< 0.9.0) but 0.9.0-2 is to be installed

see: https://packages.ubuntu.com/lunar/python3-resolvelib