### PR TITLE
Adding Ansible 8 Builds to Testing PPAs

### DIFF
--- a/latest_builds/latest_builds.py
+++ b/latest_builds/latest_builds.py
@@ -125,7 +125,7 @@ for name, config in matrix.items():
             continue
 
         print(f"    adding '{package['name']}' '{latest_pypi_version}' for {build_dists}")
-        builds.append([name, build_dists, github_branch_name, latest_pypi_version, launchpad_ppa_name])
+        builds.append([package["name"], build_dists, github_branch_name, latest_pypi_version, launchpad_ppa_name])
 
 
 for build in builds:
@@ -133,11 +133,11 @@ for build in builds:
     print(f"building '{name}' package(s)")
     print(f"  github_branch = {github_branch_name}")
     print(f"  launchpad_ppa = {launchpad_ppa_name}")
-    print(f"  building '{package['name']}' versions")
+    print(f"  building '{name}' versions")
 
-    print(f"    building '{package['name']}' '{latest_pypi_version}' for {build_dists}")
+    print(f"    building '{name}' '{latest_pypi_version}' for {build_dists}")
 
-    workflow = get_workflow(workflows, package["name"])
+    workflow = get_workflow(workflows, name)
 
     print(
         f"    running '{workflow['name']}' workflow against '{github_branch_name}' ref for '{launchpad_ppa_name}' ppa"

--- a/latest_builds/latest_builds.py
+++ b/latest_builds/latest_builds.py
@@ -117,7 +117,11 @@ for name, config in matrix.items():
         build_dists = []
 
         for dist in package["dists"]:
-            if dist not in dist_versions.keys() or Version(dist_versions[dist]) < latest_pypi_version:
+            if dist not in dist_versions.keys():
+                print(f"    '{dist}' version not found")
+                build_dists.append(dist)
+            elif Version(dist_versions[dist]) < latest_pypi_version:
+                print(f"    '{dist}' version '{Version(dist_versions[dist])}' < '{latest_pypi_version}'")
                 build_dists.append(dist)
 
         if not build_dists:

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -37,11 +37,13 @@ testing-ansible-7:
       dists:
         - jammy
         - kinetic
+        - lunar
     - name: ansible
       version_specifier: "~=7.0a"
       dists:
         - jammy
         - kinetic
+        - lunar
 testing-ansible-8:
   github_branch: ansible-8
   packages:
@@ -50,11 +52,13 @@ testing-ansible-8:
       dists:
         - jammy
         - kinetic
+        - lunar
     - name: ansible
       version_specifier: "~=8.0a"
       dists:
         - jammy
         - kinetic
+        - lunar
 testing-ansible-ansible-5:
   github_branch: ansible-5
   launchpad_ppa: testing-ansible
@@ -80,11 +84,13 @@ testing-ansible-ansible-7:
       dists:
         - jammy
         - kinetic
+        - lunar
     - name: ansible
       version_specifier: "~=7.0a"
       dists:
         - jammy
         - kinetic
+        - lunar
 ansible-5:
   packages:
     - name: resolvelib

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -1,21 +1,4 @@
 ---
-testing-ansible-5:
-  github_branch: ansible-5
-  packages:
-    - name: resolvelib
-      version_specifier: "==0.5.4"
-      dists:
-        - focal
-    - name: ansible-core
-      version_specifier: "~=2.12.0a"
-      dists:
-        - focal
-        - jammy
-    - name: ansible
-      version_specifier: "~=5.0a"
-      dists:
-        - focal
-        - jammy
 testing-ansible-6:
   github_branch: ansible-6
   packages:
@@ -37,13 +20,11 @@ testing-ansible-7:
       dists:
         - jammy
         - kinetic
-        - lunar
     - name: ansible
       version_specifier: "~=7.0a"
       dists:
         - jammy
         - kinetic
-        - lunar
 testing-ansible-8:
   github_branch: ansible-8
   packages:
@@ -59,54 +40,22 @@ testing-ansible-8:
         - jammy
         - kinetic
         - lunar
-testing-ansible-ansible-5:
-  github_branch: ansible-5
-  launchpad_ppa: testing-ansible
-  packages:
-    - name: resolvelib
-      version_specifier: "==0.5.4"
-      dists:
-        - focal
-    - name: ansible-core
-      version_specifier: "~=2.12.0a"
-      dists:
-        - focal
-    - name: ansible
-      version_specifier: "~=5.0a"
-      dists:
-        - focal
-testing-ansible-ansible-7:
-  github_branch: ansible-7
+testing-ansible-ansible-8:
+  github_branch: ansible-8
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.14.0a"
+      version_specifier: "~=2.15.0a"
       dists:
         - jammy
         - kinetic
         - lunar
     - name: ansible
-      version_specifier: "~=7.0a"
+      version_specifier: "~=8.0a"
       dists:
         - jammy
         - kinetic
         - lunar
-ansible-5:
-  packages:
-    - name: resolvelib
-      version_specifier: "==0.5.4"
-      dists:
-        - focal
-    - name: ansible-core
-      version_specifier: "~=2.12.0"
-      dists:
-        - focal
-        - jammy
-    - name: ansible
-      version_specifier: "~=5.0"
-      dists:
-        - focal
-        - jammy
 ansible-6:
   packages:
     - name: ansible-core
@@ -131,22 +80,6 @@ ansible-7:
       dists:
         - jammy
         - kinetic
-ansible-ansible-5:
-  github_branch: ansible-5
-  launchpad_ppa: ansible
-  packages:
-    - name: resolvelib
-      version_specifier: "==0.5.4"
-      dists:
-        - focal
-    - name: ansible-core
-      version_specifier: "~=2.12.0"
-      dists:
-        - focal
-    - name: ansible
-      version_specifier: "~=5.0"
-      dists:
-        - focal
 ansible-ansible-7:
   github_branch: ansible-7
   launchpad_ppa: ansible

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -42,6 +42,19 @@ testing-ansible-7:
       dists:
         - jammy
         - kinetic
+testing-ansible-8:
+  github_branch: ansible-8
+  packages:
+    - name: ansible-core
+      version_specifier: "~=2.15.0a"
+      dists:
+        - jammy
+        - kinetic
+    - name: ansible
+      version_specifier: "~=8.0a"
+      dists:
+        - jammy
+        - kinetic
 testing-ansible-ansible-5:
   github_branch: ansible-5
   launchpad_ppa: testing-ansible


### PR DESCRIPTION
- Adds Ansible 8 builds with Lunar support to the testing PPAs via the Ansible-8 branch (fixes #43)
- Removes Ansible 5 builds
- Fixes intermittent 'Broken pipe's during builds