### PR TITLE
Ansible 8 updates

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export DEB_SIGN_PROGRAM="gpg --pinentry-mode loopback --passphrase-file ${HOME}/signing.passphrase"
-export TARBALL_BASE_URL="https://pypi.python.org/packages/source"
+export TARBALL_BASE_URL="https://files.pythonhosted.org/packages/source"
 
 # handle different release types better in the changelog
 DEB_VERSION_EXTRA=$(echo "${DEB_VERSION}" | grep -Po '[a-z]+.*' || true)

--- a/ansible-core/packaging/templates/changelog
+++ b/ansible-core/packaging/templates/changelog
@@ -1,6 +1,3 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: Ansible Project, 2020
 ${DEB_NAME} (${DEB_CHANGELOG_VERSION}-${DEB_RELEASE}~${DIST}) ${DIST}; urgency=low
 
   * ${DEB_NAME} ${DEB_CHANGELOG_VERSION} release

--- a/ansible/packaging/templates/changelog
+++ b/ansible/packaging/templates/changelog
@@ -1,6 +1,3 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: Ansible Project, 2020
 ${DEB_NAME} (${DEB_CHANGELOG_VERSION}-${DEB_RELEASE}~${DIST}) ${DIST}; urgency=low
 
   * ${DEB_NAME} ${DEB_CHANGELOG_VERSION} release


### PR DESCRIPTION
- removed copyright from changelog
    ```
    # before
    # zcat /usr/share/doc/ansible/changelog.Debian.gz
    # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
    # SPDX-License-Identifier: GPL-3.0-or-later
    # SPDX-FileCopyrightText: Ansible Project, 2020
    ansible (8.0.0~a3-1ppa~jammy) jammy; urgency=low
    
      * ansible 8.0.0~a3 release
    
     -- Ansible Community Builds <ansible-community-builds@redhat.com>  Thu, 11 May 2023 04:16:55 +0000
    
    
    # after
    # zcat /usr/share/doc/ansible/changelog.Debian.gz
    ansible (8.0.0~a3-1ppa~jammy) jammy; urgency=low
    
      * ansible 8.0.0~a3 release
    
     -- Ansible Community Builds <ansible-community-builds@redhat.com>  Fri, 12 May 2023 03:26:02 +0000
    ```
- updated `TARBALL_BASE_URL` (closes #48)