### PR TITLE
fixes jinja2.exceptions.TemplateNotFound: man.j2 in ansible-7 branch

### DIFF
--- a/ansible-core/Makefile
+++ b/ansible-core/Makefile
@@ -299,7 +299,7 @@ linkcheckdocs:
 .PHONY: generate_rst
 generate_rst: lib/ansible/cli/*.py
 	mkdir -p ./docs/man/man1/ ; \
-	$(PYTHON) $(GENERATE_CLI) --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
+	$(PYTHON) $(GENERATE_CLI) --template-file=hacking/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
 
 
 docs: generate_rst


### PR DESCRIPTION
Updated template file per: https://github.com/ansible/ansible/pull/81003