### PR TITLE
fixes jinja2.exceptions.TemplateNotFound: man.j2 in ansible-6 branch

### DIFF
--- a/ansible-core/Makefile
+++ b/ansible-core/Makefile
@@ -35,7 +35,7 @@ ASCII2MAN = @echo "ERROR: rst2man from docutils command is not installed but is 
 endif
 
 PYTHON ?= python
-GENERATE_CLI = hacking/build-ansible.py generate-man
+GENERATE_CLI = packaging/pep517_backend/_generate_man.py
 
 # fetch version from project release.py as single source-of-truth
 VERSION := $(shell $(PYTHON) packaging/release/versionhelper/version_helper.py --raw || echo error)
@@ -299,7 +299,7 @@ linkcheckdocs:
 .PHONY: generate_rst
 generate_rst: lib/ansible/cli/*.py
 	mkdir -p ./docs/man/man1/ ; \
-	$(PYTHON) $(GENERATE_CLI) --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
+	$(PYTHON) $(GENERATE_CLI) --template-file=packaging/pep517_backend/_templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
 
 
 docs: generate_rst


### PR DESCRIPTION
Updated template file per: https://github.com/ansible/ansible/pull/81027