### PR TITLE
updates to enable Ansible 11 builds

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -44,8 +44,11 @@ for DIST in ${DEB_DIST}; do
 
     export DESCRIPTION='man1'
     export ORIGIN='https://github.com/ansible/ansible'
+    python3 -m venv "${HOME}"/work/.venv
+    source "${HOME}"/work/.venv/bin/activate
     pip install --requirement requirements.txt docutils
     packaging/cli-doc/build.py man --output-dir docs/man/man1
+    deactivate
     envsubst < "${HOME}"/work/ppa/ppa/"${DEB_NAME}"/packaging/templates/local-patch-header > ./debian/source/local-patch-header
     EDITOR=/bin/true dpkg-source --commit . man1
   fi

--- a/.github/scripts/install_build_depends.sh
+++ b/.github/scripts/install_build_depends.sh
@@ -6,6 +6,7 @@ sudo apt-get -y install \
     debhelper \
     devscripts \
     dh-python \
+    pybuild-plugin-pyproject \
     python3 \
     python3-pip \
     python3-setuptools \

--- a/.github/scripts/install_build_depends.sh
+++ b/.github/scripts/install_build_depends.sh
@@ -6,7 +6,8 @@ sudo apt-get -y install \
     debhelper \
     devscripts \
     dh-python \
+    python3 \
     python3-pip \
     python3-setuptools \
-    python3 \
+    python3-venv \
     wget

--- a/.github/scripts/install_build_depends.sh
+++ b/.github/scripts/install_build_depends.sh
@@ -3,6 +3,7 @@
 sudo apt-get update
 
 sudo apt-get -y install \
+    build-essential \
     debhelper \
     devscripts \
     dh-python \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.DEB_NAME }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/ansible-core/packaging/debian/control
+++ b/ansible-core/packaging/debian/control
@@ -11,8 +11,9 @@ Build-Depends:
  debhelper-compat (= 13),
  devscripts,
  dh-python,
- python3-setuptools,
- python3
+ pybuild-plugin-pyproject,
+ python3,
+ python3-setuptools
 Standards-Version: 4.4.1
 Homepage: https://ansible.com/
 Vcs-Browser: https://github.com/ansible/ansible


### PR DESCRIPTION
The following updates were needed for Ansible 11

- bumped CI to run on 'ubuntu-24.04' ([ansible-core 2.18 requires python >= 3.11, <= 3.13](https://github.com/ansible/ansible/blob/v2.18.0rc1/pyproject.toml#L23-L25) and ubuntu 22.04 has 3.10)
- added a python virtual environment to build the docs (ubuntu 24.04 with system python 3.12 will error out if you try to pip install anything to the system python unless you add `--break-system-packages`)
- added the 'pyproject' pybuild plugin (ansible-core 2.18 uses pyproject exclusively now)
- added the 'build-essential' package to resolve `Unmet build dependencies: build-essential:native` in the ubuntu 24.04 CI