### PR TITLE
Add support for Ansible 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,13 @@ Example of adding a new build: Ansible 8
       github_branch: ansible-8
       packages:
         - name: ansible-core
-          version_specifier_set: "~=2.15.0a"  # includes pre-releases
+          version_specifier_set: ">=2.15.0a,<2.16.0a"  # includes pre-releases
           dists:
             - jammy
             - kinetic
             - lunar
         - name: ansible
-          version_specifier_set: "~=8.0a"  # includes pre-releases
+          version_specifier_set: ">=8.0.0a,<9.0.0a"  # includes pre-releases
           dists:
             - jammy
             - kinetic
@@ -273,13 +273,13 @@ Example of adding a new build: Ansible 8
       launchpad_ppa: testing-ansible  # name used for the PPA
       packages:
         - name: ansible-core
-          version_specifier_set: "~=2.15.0a"
+          version_specifier_set: ">=2.15.0a,<2.16.0a"
           dists:
             - jammy
             - kinetic
             - lunar
         - name: ansible
-          version_specifier_set: "~=8.0a"
+          version_specifier_set: ">=8.0.0a,<9.0.0a"
           dists:
             - jammy
             - kinetic
@@ -293,13 +293,13 @@ Example of adding a new build: Ansible 8
           github_branch: ansible-8
           packages:
             - name: ansible-core
-              version_specifier_set: "~=2.15.0"  # does not include pre-releases
+              version_specifier_set: ">=2.15.0,<2.16.0"  # does not include pre-releases
               dists:
                 - jammy
                 - kinetic
                 - lunar
             - name: ansible
-              version_specifier_set: "~=8.0"  # does not include pre-releases
+              version_specifier_set: ">=8.0.0,<9.0.0"  # does not include pre-releases
               dists:
                 - jammy
                 - kinetic
@@ -312,13 +312,13 @@ Example of adding a new build: Ansible 8
           launchpad_ppa: ansible
           packages:
             - name: ansible-core
-              version_specifier_set: "~=2.15.0"
+              version_specifier_set: ">=2.15.0,<2.16.0"
               dists:
                 - jammy
                 - kinetic
                 - lunar
             - name: ansible
-              version_specifier_set: "~=8.0"
+              version_specifier_set: ">=8.0.0,<9.0.0"
               dists:
                 - jammy
                 - kinetic

--- a/README.md
+++ b/README.md
@@ -251,19 +251,19 @@ Example of adding a new build: Ansible 8
       github_branch: ansible-8
       packages:
         - name: ansible-core
-          version_specifier: "~=2.15.0a"  # includes pre-releases
+          version_specifier_set: "~=2.15.0a"  # includes pre-releases
           dists:
             - jammy
             - kinetic
             - lunar
         - name: ansible
-          version_specifier: "~=8.0a"  # includes pre-releases
+          version_specifier_set: "~=8.0a"  # includes pre-releases
           dists:
             - jammy
             - kinetic
             - lunar
     ```
-    For more information on the `version_specifier` see https://packaging.pypa.io/en/latest/specifiers.html
+    For more information on the `version_specifier_set` see https://packaging.pypa.io/en/latest/specifiers.html
 1. Update the build matrix in https://github.com/ansible-community/ppa/issues/1
 1. Wait for the next scheduled run or manually kick off another build.
 1. Once the builds are completed successfully, add (or bump the version of an existing entry) for the `testing-ansible` PPA
@@ -273,13 +273,13 @@ Example of adding a new build: Ansible 8
       launchpad_ppa: testing-ansible  # name used for the PPA
       packages:
         - name: ansible-core
-          version_specifier: "~=2.15.0a"
+          version_specifier_set: "~=2.15.0a"
           dists:
             - jammy
             - kinetic
             - lunar
         - name: ansible
-          version_specifier: "~=8.0a"
+          version_specifier_set: "~=8.0a"
           dists:
             - jammy
             - kinetic
@@ -293,13 +293,13 @@ Example of adding a new build: Ansible 8
           github_branch: ansible-8
           packages:
             - name: ansible-core
-              version_specifier: "~=2.15.0"  # does not include pre-releases
+              version_specifier_set: "~=2.15.0"  # does not include pre-releases
               dists:
                 - jammy
                 - kinetic
                 - lunar
             - name: ansible
-              version_specifier: "~=8.0"  # does not include pre-releases
+              version_specifier_set: "~=8.0"  # does not include pre-releases
               dists:
                 - jammy
                 - kinetic
@@ -312,13 +312,13 @@ Example of adding a new build: Ansible 8
           launchpad_ppa: ansible
           packages:
             - name: ansible-core
-              version_specifier: "~=2.15.0"
+              version_specifier_set: "~=2.15.0"
               dists:
                 - jammy
                 - kinetic
                 - lunar
             - name: ansible
-              version_specifier: "~=8.0"
+              version_specifier_set: "~=8.0"
               dists:
                 - jammy
                 - kinetic

--- a/latest_builds/latest_builds.py
+++ b/latest_builds/latest_builds.py
@@ -9,6 +9,7 @@ from packaging.version import Version
 from pathlib import Path
 from time import sleep
 
+
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
@@ -109,13 +110,14 @@ for name, config in matrix.items():
             pypi_releases[package["name"]] = available_releases
 
         filtered_versions = sorted(
-            SpecifierSet(package["version_specifier"]).filter(pypi_releases[package["name"]]), reverse=True
+            SpecifierSet(package["version_specifier_set"]).filter(pypi_releases[package["name"]]),
+            reverse=True,
         )
 
         try:
             latest_pypi_version = filtered_versions[0]
         except IndexError:
-            print(f"    '{package['name']}' version matching '{package['version_specifier']}' not found")
+            print(f"    '{package['name']}' version matching '{package['version_specifier_set']}' not found")
             continue
 
         build_dists = []
@@ -147,9 +149,7 @@ for build in builds:
 
     workflow = get_workflow(workflows, name)
 
-    print(
-        f"    running '{workflow['name']}' workflow against '{github_branch_name}' ref for '{launchpad_ppa_name}' ppa"
-    )
+    print(f"    running '{workflow['name']}' workflow against '{github_branch_name}' ref for '{launchpad_ppa_name}' ppa")
 
     run_in_progress = True
     data = {

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -49,6 +49,21 @@ testing-ansible-12:
       dists:
         - noble
         - plucky
+testing-ansible-13:
+  github_branch: ansible-13
+  packages:
+    - name: ansible-core
+      version_specifier: "~=2.20.0a"
+      dists:
+        - noble
+        - plucky
+        - questing
+    - name: ansible
+      version_specifier: "~=13.0a"
+      dists:
+        - noble
+        - plucky
+        - questing
 testing-ansible-ansible-10:
   github_branch: ansible-10
   launchpad_ppa: testing-ansible
@@ -61,20 +76,22 @@ testing-ansible-ansible-10:
       version_specifier: "~=10.0a"
       dists:
         - jammy
-testing-ansible-ansible-12:
-  github_branch: ansible-12
+testing-ansible-ansible-13:
+  github_branch: ansible-13
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.19.0a"
+      version_specifier: "~=2.20.0a"
       dists:
         - noble
         - plucky
+        - questing
     - name: ansible
-      version_specifier: "~=12.0a"
+      version_specifier: "~=13.0a"
       dists:
         - noble
         - plucky
+        - questing
 ansible-9:
   packages:
     - name: ansible-core
@@ -121,6 +138,20 @@ ansible-12:
       dists:
         - noble
         - plucky
+ansible-13:
+  packages:
+    - name: ansible-core
+      version_specifier: "~=2.20.0"
+      dists:
+        - noble
+        - plucky
+        - questing
+    - name: ansible
+      version_specifier: "~=13.0"
+      dists:
+        - noble
+        - plucky
+        - questing
 ansible-ansible-10:
   github_branch: ansible-10
   launchpad_ppa: ansible

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -3,12 +3,12 @@ testing-ansible-9:
   github_branch: ansible-9
   packages:
     - name: ansible-core
-      version_specifier: "~=2.16.0a"
+      version_specifier_set: "~=2.16.0a"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier: "~=9.0a"
+      version_specifier_set: "~=9.0a"
       dists:
         - jammy
         - noble
@@ -16,12 +16,12 @@ testing-ansible-10:
   github_branch: ansible-10
   packages:
     - name: ansible-core
-      version_specifier: "~=2.17.0a"
+      version_specifier_set: "~=2.17.0a"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier: "~=10.0a"
+      version_specifier_set: "~=10.0a"
       dists:
         - jammy
         - noble
@@ -29,23 +29,23 @@ testing-ansible-11:
   github_branch: ansible-11
   packages:
     - name: ansible-core
-      version_specifier: "~=2.18.0a"
+      version_specifier_set: "~=2.18.0a"
       dists:
         - noble
     - name: ansible
-      version_specifier: "~=11.0a"
+      version_specifier_set: "~=11.0a"
       dists:
         - noble
 testing-ansible-12:
   github_branch: ansible-12
   packages:
     - name: ansible-core
-      version_specifier: "~=2.19.0a"
+      version_specifier_set: "~=2.19.0a"
       dists:
         - noble
         - plucky
     - name: ansible
-      version_specifier: "~=12.0a"
+      version_specifier_set: "~=12.0a"
       dists:
         - noble
         - plucky
@@ -53,13 +53,13 @@ testing-ansible-13:
   github_branch: ansible-13
   packages:
     - name: ansible-core
-      version_specifier: "~=2.20.0a"
+      version_specifier_set: "~=2.20.0a"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier: "~=13.0a"
+      version_specifier_set: "~=13.0a"
       dists:
         - noble
         - plucky
@@ -69,11 +69,11 @@ testing-ansible-ansible-10:
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.17.0a"
+      version_specifier_set: "~=2.17.0a"
       dists:
         - jammy
     - name: ansible
-      version_specifier: "~=10.0a"
+      version_specifier_set: "~=10.0a"
       dists:
         - jammy
 testing-ansible-ansible-13:
@@ -81,13 +81,13 @@ testing-ansible-ansible-13:
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.20.0a"
+      version_specifier_set: "~=2.20.0a"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier: "~=13.0a"
+      version_specifier_set: "~=13.0a"
       dists:
         - noble
         - plucky
@@ -95,59 +95,59 @@ testing-ansible-ansible-13:
 ansible-9:
   packages:
     - name: ansible-core
-      version_specifier: "~=2.16.0"
+      version_specifier_set: "~=2.16.0"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier: "~=9.0"
+      version_specifier_set: "~=9.0"
       dists:
         - jammy
         - noble
 ansible-10:
   packages:
     - name: ansible-core
-      version_specifier: "~=2.17.0"
+      version_specifier_set: "~=2.17.0"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier: "~=10.0"
+      version_specifier_set: "~=10.0"
       dists:
         - jammy
         - noble
 ansible-11:
   packages:
     - name: ansible-core
-      version_specifier: "~=2.18.0"
+      version_specifier_set: "~=2.18.0"
       dists:
         - noble
     - name: ansible
-      version_specifier: "~=11.0"
+      version_specifier_set: "~=11.0"
       dists:
         - noble
 ansible-12:
   packages:
     - name: ansible-core
-      version_specifier: "~=2.19.0"
+      version_specifier_set: "~=2.19.0"
       dists:
         - noble
         - plucky
     - name: ansible
-      version_specifier: "~=12.0"
+      version_specifier_set: "~=12.0"
       dists:
         - noble
         - plucky
 ansible-13:
   packages:
     - name: ansible-core
-      version_specifier: "~=2.20.0"
+      version_specifier_set: "~=2.20.0"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier: "~=13.0"
+      version_specifier_set: "~=13.0"
       dists:
         - noble
         - plucky
@@ -157,11 +157,11 @@ ansible-ansible-10:
   launchpad_ppa: ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.17.0"
+      version_specifier_set: "~=2.17.0"
       dists:
         - jammy
     - name: ansible
-      version_specifier: "~=10.0"
+      version_specifier_set: "~=10.0"
       dists:
         - jammy
 ansible-ansible-11:
@@ -169,10 +169,10 @@ ansible-ansible-11:
   launchpad_ppa: ansible
   packages:
     - name: ansible-core
-      version_specifier: "~=2.18.0"
+      version_specifier_set: "~=2.18.0"
       dists:
         - noble
     - name: ansible
-      version_specifier: "~=11.0"
+      version_specifier_set: "~=11.0"
       dists:
         - noble

--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -3,12 +3,12 @@ testing-ansible-9:
   github_branch: ansible-9
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.16.0a"
+      version_specifier_set: ">=2.16.0a,<2.17.0a"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier_set: "~=9.0a"
+      version_specifier_set: ">=9.0.0a,<10.0.0a"
       dists:
         - jammy
         - noble
@@ -16,12 +16,12 @@ testing-ansible-10:
   github_branch: ansible-10
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.17.0a"
+      version_specifier_set: ">=2.17.0a,<2.18.0a"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier_set: "~=10.0a"
+      version_specifier_set: ">=10.0.0a,<11.0.0a"
       dists:
         - jammy
         - noble
@@ -29,23 +29,23 @@ testing-ansible-11:
   github_branch: ansible-11
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.18.0a"
+      version_specifier_set: ">=2.18.0a,<2.19.0a"
       dists:
         - noble
     - name: ansible
-      version_specifier_set: "~=11.0a"
+      version_specifier_set: ">=11.0.0a,<12.0.0a"
       dists:
         - noble
 testing-ansible-12:
   github_branch: ansible-12
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.19.0a"
+      version_specifier_set: ">=2.19.0a,<2.20.0a"
       dists:
         - noble
         - plucky
     - name: ansible
-      version_specifier_set: "~=12.0a"
+      version_specifier_set: ">=12.0.0a,<13.0.0a"
       dists:
         - noble
         - plucky
@@ -53,13 +53,13 @@ testing-ansible-13:
   github_branch: ansible-13
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.20.0a"
+      version_specifier_set: ">=2.20.0a,<2.21.0a"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier_set: "~=13.0a"
+      version_specifier_set: ">=13.0.0a,<14.0.0a"
       dists:
         - noble
         - plucky
@@ -69,11 +69,11 @@ testing-ansible-ansible-10:
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.17.0a"
+      version_specifier_set: ">=2.17.0a,<2.18.0a"
       dists:
         - jammy
     - name: ansible
-      version_specifier_set: "~=10.0a"
+      version_specifier_set: ">=10.0.0a,<11.0.0a"
       dists:
         - jammy
 testing-ansible-ansible-13:
@@ -81,13 +81,13 @@ testing-ansible-ansible-13:
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.20.0a"
+      version_specifier_set: ">=2.20.0a,<2.21.0a"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier_set: "~=13.0a"
+      version_specifier_set: ">=13.0.0a,<14.0.0a"
       dists:
         - noble
         - plucky
@@ -95,59 +95,59 @@ testing-ansible-ansible-13:
 ansible-9:
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.16.0"
+      version_specifier_set: ">=2.16.0,<2.17.0"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier_set: "~=9.0"
+      version_specifier_set: ">=9.0.0,<10.0.0"
       dists:
         - jammy
         - noble
 ansible-10:
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.17.0"
+      version_specifier_set: ">=2.17.0,<2.18.0"
       dists:
         - jammy
         - noble
     - name: ansible
-      version_specifier_set: "~=10.0"
+      version_specifier_set: ">=10.0.0,<11.0.0"
       dists:
         - jammy
         - noble
 ansible-11:
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.18.0"
+      version_specifier_set: ">=2.18.0,<2.19.0"
       dists:
         - noble
     - name: ansible
-      version_specifier_set: "~=11.0"
+      version_specifier_set: ">=11.0.0,<12.0.0"
       dists:
         - noble
 ansible-12:
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.19.0"
+      version_specifier_set: ">=2.19.0,<2.20.0"
       dists:
         - noble
         - plucky
     - name: ansible
-      version_specifier_set: "~=12.0"
+      version_specifier_set: ">=12.0.0,<13.0.0"
       dists:
         - noble
         - plucky
 ansible-13:
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.20.0"
+      version_specifier_set: ">=2.20.0,<2.21.0"
       dists:
         - noble
         - plucky
         - questing
     - name: ansible
-      version_specifier_set: "~=13.0"
+      version_specifier_set: ">=13.0.0,<14.0.0"
       dists:
         - noble
         - plucky
@@ -157,11 +157,11 @@ ansible-ansible-10:
   launchpad_ppa: ansible
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.17.0"
+      version_specifier_set: ">=2.17.0,<2.18.0"
       dists:
         - jammy
     - name: ansible
-      version_specifier_set: "~=10.0"
+      version_specifier_set: ">=10.0.0,<11.0.0"
       dists:
         - jammy
 ansible-ansible-11:
@@ -169,10 +169,10 @@ ansible-ansible-11:
   launchpad_ppa: ansible
   packages:
     - name: ansible-core
-      version_specifier_set: "~=2.18.0"
+      version_specifier_set: ">=2.18.0,<2.19.0"
       dists:
         - noble
     - name: ansible
-      version_specifier_set: "~=11.0"
+      version_specifier_set: ">=11.0.0,<12.0.0"
       dists:
         - noble


### PR DESCRIPTION
### Summary

This PR introduces support for building `ansible-13` packages and refactors the package version matching logic for better clarity and precision.

### Changes

- **Rename `version_specifier` to `version_specifier_set`**: The configuration key in `matrix.yml` has been renamed to `version_specifier_set` to more accurately reflect its purpose of defining a set of version constraints. The build script (`latest_builds.py`) and documentation (`README.md`) have been updated accordingly.

- **Use Explicit Version Ranges**: The version specifiers have been changed from compatible release operators (`~=`) to explicit bounded ranges (`>=...,<...`). This makes the version selection more explicit and less ambiguous.

- **Add `ansible-13` Builds**: New build configurations have been added to `matrix.yml` for `ansible-13` and `ansible-core-2.20`, targeting `noble`, `plucky`, and `questing` releases for both the `ansible` and `testing-ansible` PPAs.