### PR TITLE
Add support for Ansible 14 and 'resolute' distribution to build matrix

### DIFF
--- a/latest_builds/matrix.yml
+++ b/latest_builds/matrix.yml
@@ -60,6 +60,21 @@ testing-ansible-13:
       dists:
         - noble
         - questing
+testing-ansible-14:
+  github_branch: ansible-14
+  packages:
+    - name: ansible-core
+      version_specifier_set: ">=2.21.0a,<2.22.0a"
+      dists:
+        - noble
+        - questing
+        - resolute
+    - name: ansible
+      version_specifier_set: ">=14.0.0a,<15.0.0a"
+      dists:
+        - noble
+        - questing
+        - resolute
 testing-ansible-ansible-10:
   github_branch: ansible-10
   launchpad_ppa: testing-ansible
@@ -72,20 +87,22 @@ testing-ansible-ansible-10:
       version_specifier_set: ">=10.0.0a,<11.0.0a"
       dists:
         - jammy
-testing-ansible-ansible-13:
-  github_branch: ansible-13
+testing-ansible-ansible-14:
+  github_branch: ansible-14
   launchpad_ppa: testing-ansible
   packages:
     - name: ansible-core
-      version_specifier_set: ">=2.20.0a,<2.21.0a"
+      version_specifier_set: ">=2.21.0a,<2.22.0a"
       dists:
         - noble
         - questing
+        - resolute
     - name: ansible
-      version_specifier_set: ">=13.0.0a,<14.0.0a"
+      version_specifier_set: ">=14.0.0a,<15.0.0a"
       dists:
         - noble
         - questing
+        - resolute
 ansible-9:
   packages:
     - name: ansible-core
@@ -142,6 +159,20 @@ ansible-13:
       dists:
         - noble
         - questing
+ansible-14:
+  packages:
+    - name: ansible-core
+      version_specifier_set: ">=2.21.0,<2.22.0"
+      dists:
+        - noble
+        - questing
+        - resolute
+    - name: ansible
+      version_specifier_set: ">=14.0.0,<15.0.0"
+      dists:
+        - noble
+        - questing
+        - resolute
 ansible-ansible-10:
   github_branch: ansible-10
   launchpad_ppa: ansible


### PR DESCRIPTION
- Added ansible-14 and testing-ansible-14 build configurations.
- Updated testing-ansible PPA tracking from Ansible 13 (ansible-core 2.20) to Ansible 14 (ansible-core 2.21).
- Added the resolute distribution as a build target for all Ansible 14 configurations.

closes: #128