### PR TITLE
Fix pyproject.toml PEP 639 license parsing on older Ubuntu distros

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -34,6 +34,15 @@ for DIST in ${DEB_DIST}; do
   cp -a "${HOME}"/work/ppa/ppa/"${DEB_NAME}"/packaging/debian ./
   envsubst < "${HOME}"/work/ppa/ppa/"${DEB_NAME}"/packaging/templates/changelog > ./debian/changelog
 
+  # Fix setuptools < 77 PEP 639 compatibility for older Ubuntu distros like Noble
+  if [[ -f "pyproject.toml" ]]; then
+    SETUPTOOLS_VER=$(python3 -c 'import setuptools; print(setuptools.__version__.split(".")[0])' 2>/dev/null)
+    if [[ "${SETUPTOOLS_VER}" -lt 77 ]]; then
+      sed -i 's/^license = "GPL-3.0-or-later"/license = {text = "GPL-3.0-or-later"}/' pyproject.toml
+      sed -i '/^license-files = \[/,/\]/d' pyproject.toml
+    fi
+  fi
+
   # include the examples and man1 if ansible-core
   if [[ "${DEB_NAME}" == "ansible-core" ]]; then
     export DESCRIPTION='examples'


### PR DESCRIPTION
Newer versions of ansible-core (2.21.0-rc1+) use the modern PEP 639 syntax for `project.license` and `project.license-files` fields in pyproject.toml. This syntax is strictly unsupported by setuptools < 77.

Since Ubuntu 24.04 (Noble) ships with older versions of setuptools (68.1.2), pybuild throws a fatal ValueError when attempting to parse the wheel configuration.

This commit introduces a dynamic version check during the Debian build prep phase. If setuptools is older than v77, it patches pyproject.toml to revert the license fields to the older PEP 621 format, allowing the PPA package to successfully compile.